### PR TITLE
[CU-86badwmy5] Grant workbench user read access to workflow-file-outputs bucket

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -3,6 +3,8 @@ data "aws_caller_identity" "current" {}
 locals {
   output_bucket_name = coalesce(var.output_bucket_name, "${var.project_name}-raw-output")
 
+  workflow_file_outputs_bucket_name = "${var.project_name}-workflow-file-outputs"
+
   genome_references_bucket_default = lookup(coalesce(var.genome_references_bucket_region_map, {}), var.aws_region, null)
 
   additional_buckets = var.additional_buckets != null ? var.additional_buckets : []
@@ -12,7 +14,7 @@ locals {
   buckets = [
     for bucket in concat([
       aws_s3_bucket.output_bucket.bucket
-    ], local.additional_buckets, local.genome_references_bucket) : "arn:aws:s3:::${bucket}"
+    ], local.additional_buckets, local.genome_references_bucket, [local.workflow_file_outputs_bucket_name]) : "arn:aws:s3:::${bucket}"
   ]
 
   service_policy_buckets = [


### PR DESCRIPTION
## What

Adds `s3:ListBucket` and `s3:GetObject` on `<project_name>-workflow-file-outputs` to the `workbench-health-omics` user policy (`HealthOmicsUserPolicy`).

## Why

Workbench users need to preview workflow output files, which live in the `<project_name>-workflow-file-outputs` bucket (created by `hifisolves-resources`). This grants the read access required for that preview. Deriving the bucket name from `project_name` means the grant applies to all current and future AWS HiFi Solves nodes with no per-env configuration.

This codifies a change that was applied manually in the GeneDx (GDX) account for testing. Note: the manual `GetObject` entry omitted the `/*` suffix (so it didn't actually permit object reads); this change emits the correct `<bucket>/*` form via the existing `local.buckets` mechanism, which also drives the `ListBucket`/`GetObject` statements for the raw-output and genome-references buckets.

## Rollout

This module is pinned by commit SHA in `dnastack-deployment-templates/terraform/aws/healthomics-engine`. A companion PR bumps that ref to pull this in; the Concourse terraform jobs then apply it per environment (for GeneDx, the apply reconciles the manual policy into Terraform and adds the missing `/*`).

ClickUp: https://app.clickup.com/t/86badwmy5

🤖 Generated with [Claude Code](https://claude.com/claude-code)