### PR TITLE
[CU-86bb9p4kc] Expire raw-output contents instead of growing without bound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ terraform.rc
 *.iws
 *.iml
 *.ipr
+
+### Python ###
+.venv/
+__pycache__/
+function_source/tagger.zip

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The output bucket expires its contents through three lifecycle rules:
 
 Tune with `output_bucket_expiration_days`, `output_bucket_max_retention_days` and
 `output_bucket_abort_multipart_days`. There is no switch to disable expiration; an
-environment with a retention obligation raises `output_bucket_max_retention_days`.
+environment with a retention obligation raises `output_bucket_expiration_days`, which
+governs the outputs themselves. `output_bucket_max_retention_days` extends only the run
+logs and manifests, and must stay above it.
 
 ### Why objects are tagged
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The output bucket expires its contents through three lifecycle rules:
 
 | Rule | Scope | Default |
 |---|---|---|
-| `expire-transient-outputs` | objects tagged `retention=transient` | 14 days |
+| `expire-tagged-outputs` | objects tagged `expire=true` | 14 days |
 | `expire-all` | every object | 90 days |
 | `abort-incomplete-multipart` | incomplete multipart uploads | 7 days |
 
@@ -46,16 +46,16 @@ matching and no negation — and HealthOmics keys are `<run-id>/logs/…` and
 `<run-id>/out/…`, so no literal prefix can reach the segment that distinguishes
 them. "Everything except run logs and manifests" is therefore expressed by tagging:
 the `<bucket>-tagger` Lambda runs on `s3:ObjectCreated:*` and applies
-`retention=transient` to every object whose key does not end in `.log` or `.json`
+`expire=true` to every object whose key does not end in `.log` or `.json`
 (case-insensitive). New output types are covered automatically — there is no
 extension list to maintain.
 
 Objects the tagger misses carry no tag and are governed by `expire-all`, so a
 tagging outage costs a bounded window rather than unbounded growth.
 
-The `retention` key is reserved for this function; anything else that writes
+The `expire` key is reserved for this function; anything else that writes
 it on this bucket will have its value overwritten. The tag key and value are
-passed to the Lambda by Terraform (`RETENTION_TAG_KEY` / `RETENTION_TAG_VALUE`,
+passed to the Lambda by Terraform (`EXPIRE_TAG_KEY` / `EXPIRE_TAG_VALUE`,
 sourced from the same locals as the lifecycle rule's filter), so they cannot
 drift from the lifecycle rule that depends on them.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ extension list to maintain.
 Objects the tagger misses carry no tag and are governed by `expire-all`, so a
 tagging outage costs a bounded window rather than unbounded growth.
 
+The `retention` key is reserved for this function; anything else that writes
+it on this bucket will have its value overwritten.
+
 Two constraints on changes here:
 
 - The notification must stay `s3:ObjectCreated:*`. Outputs are large enough to be

--- a/README.md
+++ b/README.md
@@ -24,3 +24,40 @@ Set `enable_vpc_networking = true` and pass `vpc_id`, `private_subnet_ids`, and
 `private_route_table_ids` to create the VPC endpoints, the omics-ENI egress
 security group, and the `awscc_omics_configuration` resource. Workflow runs opt in
 per-run via `StartRun --networking-mode VPC --configuration-name <name>`.
+
+## Output bucket retention
+
+The output bucket expires its contents through three lifecycle rules:
+
+| Rule | Scope | Default |
+|---|---|---|
+| `expire-transient-outputs` | objects tagged `retention=transient` | 14 days |
+| `expire-all` | every object | 90 days |
+| `abort-incomplete-multipart` | incomplete multipart uploads | 7 days |
+
+Tune with `output_bucket_expiration_days`, `output_bucket_max_retention_days` and
+`output_bucket_abort_multipart_days`. There is no switch to disable expiration; an
+environment with a retention obligation raises `output_bucket_max_retention_days`.
+
+### Why objects are tagged
+
+S3 lifecycle filters accept only prefix, tag and object-size conditions — no suffix
+matching and no negation — and HealthOmics keys are `<run-id>/logs/…` and
+`<run-id>/out/…`, so no literal prefix can reach the segment that distinguishes
+them. "Everything except run logs and manifests" is therefore expressed by tagging:
+the `<bucket>-tagger` Lambda runs on `s3:ObjectCreated:*` and applies
+`retention=transient` to every object whose key does not end in `.log` or `.json`
+(case-insensitive). New output types are covered automatically — there is no
+extension list to maintain.
+
+Objects the tagger misses carry no tag and are governed by `expire-all`, so a
+tagging outage costs a bounded window rather than unbounded growth.
+
+Two constraints on changes here:
+
+- The notification must stay `s3:ObjectCreated:*`. Outputs are large enough to be
+  multipart uploads, which emit `CompleteMultipartUpload` rather than `Put`.
+- S3 allows one notification configuration per bucket, so this module owns it.
+
+Handler source is `function_source/tagger.py`; run its tests with
+`pytest tests/` after `pip install pytest boto3`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Objects the tagger misses carry no tag and are governed by `expire-all`, so a
 tagging outage costs a bounded window rather than unbounded growth.
 
 The `retention` key is reserved for this function; anything else that writes
-it on this bucket will have its value overwritten.
+it on this bucket will have its value overwritten. The tag key and value are
+passed to the Lambda by Terraform (`RETENTION_TAG_KEY` / `RETENTION_TAG_VALUE`,
+sourced from the same locals as the lifecycle rule's filter), so they cannot
+drift from the lifecycle rule that depends on them.
 
 Two constraints on changes here:
 

--- a/data.tf
+++ b/data.tf
@@ -28,8 +28,8 @@ locals {
     for account in var.external_ecr_accounts : "arn:aws:ecr:${var.aws_region}:${account}:*"
   ])
 
-  transient_tag_key   = "retention"
-  transient_tag_value = "transient"
+  expire_tag_key   = "expire"
+  expire_tag_value = "true"
 }
 
 

--- a/data.tf
+++ b/data.tf
@@ -27,6 +27,9 @@ locals {
   ecr_resources = concat(["arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:*"], [
     for account in var.external_ecr_accounts : "arn:aws:ecr:${var.aws_region}:${account}:*"
   ])
+
+  transient_tag_key   = "retention"
+  transient_tag_value = "transient"
 }
 
 
@@ -218,5 +221,39 @@ data "aws_iam_policy_document" "output_bucket_policy" {
       variable = "aws:SecureTransport"
       values   = ["false"]
     }
+  }
+}
+
+data "aws_iam_policy_document" "output_bucket_tagger_trust" {
+  statement {
+    sid     = "AllowLambdaService"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "output_bucket_tagger" {
+  statement {
+    sid = "TagOutputObjects"
+    actions = [
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+    ]
+
+    resources = ["${aws_s3_bucket.output_bucket.arn}/*"]
+  }
+
+  statement {
+    sid = "WriteFunctionLogs"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["${aws_cloudwatch_log_group.output_bucket_tagger.arn}:*"]
   }
 }

--- a/function_source/tagger.py
+++ b/function_source/tagger.py
@@ -8,14 +8,13 @@ catch-all rule then governs.
 """
 
 import logging
+import os
 import urllib.parse
 
 import boto3
 from botocore.exceptions import ClientError
 
 RETAINED_SUFFIXES = (".log", ".json")
-TAG_KEY = "retention"
-TAG_VALUE = "transient"
 
 # The object was removed between the notification and the tagging call. Routine
 # when HealthOmics cleans up its own intermediates, and nothing is left to expire.
@@ -23,6 +22,19 @@ GONE_ERROR_CODES = ("NoSuchKey", "NoSuchVersion", "404")
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+def _required_env(name):
+    """Read a required environment variable, failing loudly if it's absent.
+
+    No default: the tag key and value must match the lifecycle rule's filter
+    exactly, and a silent default here would recreate the same drift risk the
+    Terraform-sourced environment variables exist to close.
+    """
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"required environment variable {name} is not set")
+    return value
 
 
 def is_transient(key):
@@ -45,22 +57,22 @@ def record_key(record):
     )
 
 
-def object_keys(event):
-    """Yield (bucket, key) for each record, with the key percent-decoded."""
-    for record in event.get("Records", []):
-        yield record_key(record)
-
-
 def tag_transient(client, bucket, key):
     """Add the expiry tag, preserving any tags already on the object.
 
     PutObjectTagging replaces the whole tag set, so read-modify-write. This
-    function owns the `retention` tag key on this bucket and overwrites any
-    existing value, so the key must not be used for any other purpose here.
+    function owns the tag key named by RETENTION_TAG_KEY on this bucket and
+    overwrites any existing value, so that key must not be used for any other
+    purpose here. The key and value come from Terraform (RETENTION_TAG_KEY /
+    RETENTION_TAG_VALUE) so they can never drift from the lifecycle rule's
+    filter, which reads the same locals.
     """
+    tag_key = _required_env("RETENTION_TAG_KEY")
+    tag_value = _required_env("RETENTION_TAG_VALUE")
+
     existing = client.get_object_tagging(Bucket=bucket, Key=key)["TagSet"]
-    tags = [tag for tag in existing if tag["Key"] != TAG_KEY]
-    tags.append({"Key": TAG_KEY, "Value": TAG_VALUE})
+    tags = [tag for tag in existing if tag["Key"] != tag_key]
+    tags.append({"Key": tag_key, "Value": tag_value})
     client.put_object_tagging(Bucket=bucket, Key=key, Tagging={"TagSet": tags})
 
 

--- a/function_source/tagger.py
+++ b/function_source/tagger.py
@@ -34,19 +34,29 @@ def is_transient(key):
     return not key.lower().endswith(RETAINED_SUFFIXES)
 
 
+def record_key(record):
+    """Extract (bucket, key) from a single S3 event record, key percent-decoded.
+
+    Raises KeyError if the record is missing either field.
+    """
+    return (
+        record["s3"]["bucket"]["name"],
+        urllib.parse.unquote_plus(record["s3"]["object"]["key"]),
+    )
+
+
 def object_keys(event):
     """Yield (bucket, key) for each record, with the key percent-decoded."""
     for record in event.get("Records", []):
-        yield (
-            record["s3"]["bucket"]["name"],
-            urllib.parse.unquote_plus(record["s3"]["object"]["key"]),
-        )
+        yield record_key(record)
 
 
 def tag_transient(client, bucket, key):
     """Add the expiry tag, preserving any tags already on the object.
 
-    PutObjectTagging replaces the whole tag set, so read-modify-write.
+    PutObjectTagging replaces the whole tag set, so read-modify-write. This
+    function owns the `retention` tag key on this bucket and overwrites any
+    existing value, so the key must not be used for any other purpose here.
     """
     existing = client.get_object_tagging(Bucket=bucket, Key=key)["TagSet"]
     tags = [tag for tag in existing if tag["Key"] != TAG_KEY]
@@ -55,18 +65,26 @@ def tag_transient(client, bucket, key):
 
 
 def handler(event, context, client=None):
-    """Tag every eligible record, even if some records fail.
+    """Tag every eligible record, even if some records fail or are malformed.
 
-    One bad object must not stop the rest of the batch from being tagged, so
-    unexpected errors are collected rather than raised immediately. Once every
-    record has been attempted, the invocation still fails (re-raising the last
-    error) so Lambda records and retries it — there is no other monitoring on
-    this function, so that failed-invocation signal is what surfaces problems.
+    One bad or malformed record must not stop the rest of the batch from being
+    tagged, so both extraction failures and unexpected tagging errors are
+    collected rather than raised immediately. Once every record has been
+    attempted, the invocation still fails (re-raising the last error) so
+    Lambda records and retries it — there is no other monitoring on this
+    function, so that failed-invocation signal is what surfaces problems.
     """
     client = client or boto3.client("s3")
 
     failures = []
-    for bucket, key in object_keys(event):
+    for record in event.get("Records", []):
+        try:
+            bucket, key = record_key(record)
+        except KeyError as error:
+            logger.error("malformed record, skipping: %r (%s)", record, error)
+            failures.append(error)
+            continue
+
         if not is_transient(key):
             logger.info("retaining s3://%s/%s", bucket, key)
             continue

--- a/function_source/tagger.py
+++ b/function_source/tagger.py
@@ -55,8 +55,17 @@ def tag_transient(client, bucket, key):
 
 
 def handler(event, context, client=None):
+    """Tag every eligible record, even if some records fail.
+
+    One bad object must not stop the rest of the batch from being tagged, so
+    unexpected errors are collected rather than raised immediately. Once every
+    record has been attempted, the invocation still fails (re-raising the last
+    error) so Lambda records and retries it — there is no other monitoring on
+    this function, so that failed-invocation signal is what surfaces problems.
+    """
     client = client or boto3.client("s3")
 
+    failures = []
     for bucket, key in object_keys(event):
         if not is_transient(key):
             logger.info("retaining s3://%s/%s", bucket, key)
@@ -67,4 +76,8 @@ def handler(event, context, client=None):
             if error.response["Error"]["Code"] in GONE_ERROR_CODES:
                 logger.info("skipping s3://%s/%s: object no longer exists", bucket, key)
                 continue
-            raise
+            logger.error("failed to tag s3://%s/%s: %s", bucket, key, error)
+            failures.append(error)
+
+    if failures:
+        raise failures[-1]

--- a/function_source/tagger.py
+++ b/function_source/tagger.py
@@ -1,0 +1,70 @@
+"""Tag HealthOmics run outputs so an S3 lifecycle rule can expire them early.
+
+The bucket's lifecycle rules cannot express "everything except these suffixes":
+S3 filters offer no suffix matching and no negation. So this function evaluates
+the exclusion — it sees the full key — and tags what should expire. Objects whose
+keys end in a retained suffix are deliberately left untagged, which the 90-day
+catch-all rule then governs.
+"""
+
+import logging
+import urllib.parse
+
+import boto3
+from botocore.exceptions import ClientError
+
+RETAINED_SUFFIXES = (".log", ".json")
+TAG_KEY = "retention"
+TAG_VALUE = "transient"
+
+# The object was removed between the notification and the tagging call. Routine
+# when HealthOmics cleans up its own intermediates, and nothing is left to expire.
+GONE_ERROR_CODES = ("NoSuchKey", "NoSuchVersion", "404")
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def is_transient(key):
+    """True when the object should be tagged for early expiration.
+
+    Matched case-insensitively so an unexpectedly-cased run log is retained
+    rather than expired — absence of the tag is the fail-safe direction.
+    """
+    return not key.lower().endswith(RETAINED_SUFFIXES)
+
+
+def object_keys(event):
+    """Yield (bucket, key) for each record, with the key percent-decoded."""
+    for record in event.get("Records", []):
+        yield (
+            record["s3"]["bucket"]["name"],
+            urllib.parse.unquote_plus(record["s3"]["object"]["key"]),
+        )
+
+
+def tag_transient(client, bucket, key):
+    """Add the expiry tag, preserving any tags already on the object.
+
+    PutObjectTagging replaces the whole tag set, so read-modify-write.
+    """
+    existing = client.get_object_tagging(Bucket=bucket, Key=key)["TagSet"]
+    tags = [tag for tag in existing if tag["Key"] != TAG_KEY]
+    tags.append({"Key": TAG_KEY, "Value": TAG_VALUE})
+    client.put_object_tagging(Bucket=bucket, Key=key, Tagging={"TagSet": tags})
+
+
+def handler(event, context, client=None):
+    client = client or boto3.client("s3")
+
+    for bucket, key in object_keys(event):
+        if not is_transient(key):
+            logger.info("retaining s3://%s/%s", bucket, key)
+            continue
+        try:
+            tag_transient(client, bucket, key)
+        except ClientError as error:
+            if error.response["Error"]["Code"] in GONE_ERROR_CODES:
+                logger.info("skipping s3://%s/%s: object no longer exists", bucket, key)
+                continue
+            raise

--- a/function_source/tagger.py
+++ b/function_source/tagger.py
@@ -37,7 +37,7 @@ def _required_env(name):
     return value
 
 
-def is_transient(key):
+def should_expire(key):
     """True when the object should be tagged for early expiration.
 
     Matched case-insensitively so an unexpectedly-cased run log is retained
@@ -57,18 +57,18 @@ def record_key(record):
     )
 
 
-def tag_transient(client, bucket, key):
+def tag_for_expiry(client, bucket, key):
     """Add the expiry tag, preserving any tags already on the object.
 
     PutObjectTagging replaces the whole tag set, so read-modify-write. This
-    function owns the tag key named by RETENTION_TAG_KEY on this bucket and
+    function owns the tag key named by EXPIRE_TAG_KEY on this bucket and
     overwrites any existing value, so that key must not be used for any other
-    purpose here. The key and value come from Terraform (RETENTION_TAG_KEY /
-    RETENTION_TAG_VALUE) so they can never drift from the lifecycle rule's
+    purpose here. The key and value come from Terraform (EXPIRE_TAG_KEY /
+    EXPIRE_TAG_VALUE) so they can never drift from the lifecycle rule's
     filter, which reads the same locals.
     """
-    tag_key = _required_env("RETENTION_TAG_KEY")
-    tag_value = _required_env("RETENTION_TAG_VALUE")
+    tag_key = _required_env("EXPIRE_TAG_KEY")
+    tag_value = _required_env("EXPIRE_TAG_VALUE")
 
     existing = client.get_object_tagging(Bucket=bucket, Key=key)["TagSet"]
     tags = [tag for tag in existing if tag["Key"] != tag_key]
@@ -97,11 +97,11 @@ def handler(event, context, client=None):
             failures.append(error)
             continue
 
-        if not is_transient(key):
+        if not should_expire(key):
             logger.info("retaining s3://%s/%s", bucket, key)
             continue
         try:
-            tag_transient(client, bucket, key)
+            tag_for_expiry(client, bucket, key)
         except ClientError as error:
             if error.response["Error"]["Code"] in GONE_ERROR_CODES:
                 logger.info("skipping s3://%s/%s: object no longer exists", bucket, key)

--- a/lifecycle.tf
+++ b/lifecycle.tf
@@ -1,0 +1,57 @@
+resource "aws_s3_bucket_lifecycle_configuration" "output_bucket" {
+  bucket = aws_s3_bucket.output_bucket.id
+
+  # Everything the tagger marked: all workflow outputs except run logs and manifests.
+  rule {
+    id     = "expire-transient-outputs"
+    status = "Enabled"
+
+    filter {
+      tag {
+        key   = local.transient_tag_key
+        value = local.transient_tag_value
+      }
+    }
+
+    expiration {
+      days = var.output_bucket_expiration_days
+    }
+  }
+
+  # Backstop. Objects the tagger never reached carry no tag and would otherwise
+  # live forever; this bounds that to a known window. On a healthy bucket the only
+  # objects it deletes are the run logs and manifests, so it doubles as their
+  # retention policy. A whole-bucket rule cannot exclude them: that would need them
+  # tagged, and then a tagger failure means no tag and no expiry — the original bug.
+  rule {
+    id     = "expire-all"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.output_bucket_max_retention_days
+    }
+  }
+
+  # Parts of interrupted multipart uploads are billed indefinitely but appear in
+  # neither object listings nor CloudWatch BucketSizeBytes. Age is the only way to
+  # tell an abandoned upload from an in-flight one.
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.output_bucket_abort_multipart_days
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.output_bucket_expiration_days < var.output_bucket_max_retention_days
+      error_message = "output_bucket_expiration_days must be less than output_bucket_max_retention_days, otherwise the catch-all rule would expire tagged objects first and the tag would have no effect."
+    }
+  }
+}

--- a/lifecycle.tf
+++ b/lifecycle.tf
@@ -3,13 +3,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "output_bucket" {
 
   # Everything the tagger marked: all workflow outputs except run logs and manifests.
   rule {
-    id     = "expire-transient-outputs"
+    id     = "expire-tagged-outputs"
     status = "Enabled"
 
     filter {
       tag {
-        key   = local.transient_tag_key
-        value = local.transient_tag_value
+        key   = local.expire_tag_key
+        value = local.expire_tag_value
       }
     }
 

--- a/tagger.tf
+++ b/tagger.tf
@@ -1,0 +1,82 @@
+resource "archive_file" "output_bucket_tagger" {
+  type        = "zip"
+  output_path = "${path.module}/function_source/tagger.zip"
+
+  source {
+    content  = file("${path.module}/function_source/tagger.py")
+    filename = "index.py"
+  }
+}
+
+resource "aws_iam_role" "output_bucket_tagger" {
+  name               = "${local.output_bucket_name}-tagger"
+  assume_role_policy = data.aws_iam_policy_document.output_bucket_tagger_trust.json
+
+  tags = {
+    created_by = "terraform"
+  }
+}
+
+resource "aws_iam_role_policy" "output_bucket_tagger" {
+  name   = "tag-transient-outputs"
+  role   = aws_iam_role.output_bucket_tagger.id
+  policy = data.aws_iam_policy_document.output_bucket_tagger.json
+}
+
+resource "aws_cloudwatch_log_group" "output_bucket_tagger" {
+  name              = "/aws/lambda/${local.output_bucket_name}-tagger"
+  retention_in_days = 30
+
+  tags = {
+    created_by = "terraform"
+  }
+}
+
+resource "aws_lambda_function" "output_bucket_tagger" {
+  function_name = "${local.output_bucket_name}-tagger"
+  description   = "Tags non-log, non-manifest objects so the bucket lifecycle rules expire them"
+  role          = aws_iam_role.output_bucket_tagger.arn
+  runtime       = "python3.13"
+  handler       = "index.handler"
+  timeout       = 30
+
+  filename = "${path.module}/function_source/tagger.zip"
+
+  # Hashes the committed source rather than the generated zip. Referencing the
+  # archive resource's own output would make this unknown-at-plan on every run,
+  # republishing the function and putting churn into every plan.
+  source_code_hash = filebase64sha256("${path.module}/function_source/tagger.py")
+
+  depends_on = [
+    archive_file.output_bucket_tagger,
+    aws_cloudwatch_log_group.output_bucket_tagger,
+  ]
+
+  tags = {
+    created_by = "terraform"
+  }
+}
+
+resource "aws_lambda_permission" "output_bucket_tagger" {
+  statement_id   = "AllowExecutionFromOutputBucket"
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.output_bucket_tagger.function_name
+  principal      = "s3.amazonaws.com"
+  source_arn     = aws_s3_bucket.output_bucket.arn
+  source_account = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_s3_bucket_notification" "output_bucket" {
+  bucket = aws_s3_bucket.output_bucket.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.output_bucket_tagger.arn
+
+    # Must stay a wildcard. Every .bam averages ~21 GB and therefore arrives as
+    # CompleteMultipartUpload, not Put; narrowing this would silently miss
+    # 99.17% of the bucket with no error and no visible symptom.
+    events = ["s3:ObjectCreated:*"]
+  }
+
+  depends_on = [aws_lambda_permission.output_bucket_tagger]
+}

--- a/tagger.tf
+++ b/tagger.tf
@@ -1,3 +1,10 @@
+# This archive regenerates only on create/replace; archive_file never notices
+# output_path missing on disk, so the zip is normally absent from the apply
+# container. Safe because the Lambda below only reads filename on create,
+# replace, or a code change (which replaces this archive too). Exception: a
+# ForceNew Lambda replacement with tagger.py unchanged (in practice, changing
+# output_bucket_name) fails on the missing zip. Recover with:
+# terraform apply -replace=archive_file.output_bucket_tagger
 resource "archive_file" "output_bucket_tagger" {
   type        = "zip"
   output_path = "${path.module}/function_source/tagger.zip"

--- a/tagger.tf
+++ b/tagger.tf
@@ -3,7 +3,7 @@
 # container. Safe because the Lambda below only reads filename on create,
 # replace, or a code change (which replaces this archive too). Exception: a
 # ForceNew Lambda replacement with tagger.py unchanged (in practice, changing
-# output_bucket_name) fails on the missing zip. Recover with:
+# output_bucket_name or project_name) fails on the missing zip. Recover with:
 # terraform apply -replace=archive_file.output_bucket_tagger
 resource "archive_file" "output_bucket_tagger" {
   type        = "zip"

--- a/tagger.tf
+++ b/tagger.tf
@@ -54,6 +54,13 @@ resource "aws_lambda_function" "output_bucket_tagger" {
   # republishing the function and putting churn into every plan.
   source_code_hash = filebase64sha256("${path.module}/function_source/tagger.py")
 
+  environment {
+    variables = {
+      RETENTION_TAG_KEY   = local.transient_tag_key
+      RETENTION_TAG_VALUE = local.transient_tag_value
+    }
+  }
+
   depends_on = [
     archive_file.output_bucket_tagger,
     aws_cloudwatch_log_group.output_bucket_tagger,

--- a/tagger.tf
+++ b/tagger.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role" "output_bucket_tagger" {
 }
 
 resource "aws_iam_role_policy" "output_bucket_tagger" {
-  name   = "tag-transient-outputs"
+  name   = "tag-expiring-outputs"
   role   = aws_iam_role.output_bucket_tagger.id
   policy = data.aws_iam_policy_document.output_bucket_tagger.json
 }
@@ -56,8 +56,8 @@ resource "aws_lambda_function" "output_bucket_tagger" {
 
   environment {
     variables = {
-      RETENTION_TAG_KEY   = local.transient_tag_key
-      RETENTION_TAG_VALUE = local.transient_tag_value
+      EXPIRE_TAG_KEY   = local.expire_tag_key
+      EXPIRE_TAG_VALUE = local.expire_tag_value
     }
   }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/awscc"
       version = ">= 1.78.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.5.0"
+    }
   }
   required_version = "~> 1.7"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,5 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "function_source"))
 
-os.environ.setdefault("RETENTION_TAG_KEY", "retention")
-os.environ.setdefault("RETENTION_TAG_VALUE", "transient")
+os.environ["EXPIRE_TAG_KEY"] = "expire"
+os.environ["EXPIRE_TAG_VALUE"] = "true"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "function_source"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
+import os
 import pathlib
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "function_source"))
+
+os.environ.setdefault("RETENTION_TAG_KEY", "retention")
+os.environ.setdefault("RETENTION_TAG_VALUE", "transient")

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -179,6 +179,25 @@ def test_handler_tags_other_records_then_raises_on_unexpected_error():
     ]
 
 
+def test_handler_tags_other_records_and_raises_on_a_malformed_middle_record():
+    client = FakeS3()
+    event = {
+        "Records": [
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/c.bam"}}},
+        ]
+    }
+
+    with pytest.raises(KeyError):
+        tagger.handler(event, None, client=client)
+
+    assert [call["Key"] for call in client.put_calls] == [
+        "run-1/out/a.bam",
+        "run-1/out/c.bam",
+    ]
+
+
 def test_handler_tags_other_records_and_does_not_raise_on_a_deleted_middle_record():
     client = KeyedFakeS3(errors={"run-1/out/b.bam": client_error("NoSuchKey")})
     event = {

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -5,37 +5,24 @@ import tagger
 
 
 class FakeS3:
-    """Minimal stand-in for the S3 client, recording put calls."""
+    """Stand-in for the S3 client, recording put calls.
 
-    def __init__(self, tag_set=None, get_error=None):
-        self.tag_set = tag_set if tag_set is not None else []
-        self.get_error = get_error
-        self.put_calls = []
-
-    def get_object_tagging(self, **kwargs):
-        if self.get_error is not None:
-            raise self.get_error
-        return {"TagSet": list(self.tag_set)}
-
-    def put_object_tagging(self, **kwargs):
-        self.put_calls.append(kwargs)
-
-
-class KeyedFakeS3:
-    """Stand-in for the S3 client where the failure is keyed per object.
-
-    Lets a single record in a batch fail (or be gone) while the rest succeed.
+    `errors` maps an object key to the exception get_object_tagging should
+    raise for that key. A `None` entry is the fallback applied to every key
+    that has no key-specific entry, which lets a single call site express
+    "every call in this test fails the same way."
     """
 
-    def __init__(self, errors=None):
+    def __init__(self, tag_set=None, errors=None):
+        self.tag_set = tag_set if tag_set is not None else []
         self.errors = errors or {}
         self.put_calls = []
 
     def get_object_tagging(self, **kwargs):
-        error = self.errors.get(kwargs["Key"])
+        error = self.errors.get(kwargs["Key"], self.errors.get(None))
         if error is not None:
             raise error
-        return {"TagSet": []}
+        return {"TagSet": list(self.tag_set)}
 
     def put_object_tagging(self, **kwargs):
         self.put_calls.append(kwargs)
@@ -45,8 +32,13 @@ def client_error(code, operation="GetObjectTagging"):
     return ClientError({"Error": {"Code": code, "Message": code}}, operation)
 
 
-def s3_event(key, bucket="hfs-bch-raw-output"):
-    return {"Records": [{"s3": {"bucket": {"name": bucket}, "object": {"key": key}}}]}
+def s3_event(*keys, bucket="hfs-bch-raw-output"):
+    return {
+        "Records": [
+            {"s3": {"bucket": {"name": bucket}, "object": {"key": key}}}
+            for key in keys
+        ]
+    }
 
 
 @pytest.mark.parametrize(
@@ -78,16 +70,12 @@ def test_is_transient_false_for_retained_suffixes(key):
     assert tagger.is_transient(key) is False
 
 
-def test_object_keys_decodes_plus_and_percent_escapes():
-    event = s3_event("run+1/out/my+file.bam")
-    assert list(tagger.object_keys(event)) == [
-        ("hfs-bch-raw-output", "run 1/out/my file.bam")
-    ]
+def test_record_key_decodes_plus_and_percent_escapes():
+    record = s3_event("run+1/out/my+file.bam")["Records"][0]
+    assert tagger.record_key(record) == ("hfs-bch-raw-output", "run 1/out/my file.bam")
 
-    event = s3_event("run-1/out/a%20b.bam")
-    assert list(tagger.object_keys(event)) == [
-        ("hfs-bch-raw-output", "run-1/out/a b.bam")
-    ]
+    record = s3_event("run-1/out/a%20b.bam")["Records"][0]
+    assert tagger.record_key(record) == ("hfs-bch-raw-output", "run-1/out/a b.bam")
 
 
 def test_tag_transient_preserves_existing_tags():
@@ -119,6 +107,15 @@ def test_tag_transient_replaces_an_existing_retention_tag():
     ]
 
 
+@pytest.mark.parametrize("missing_var", ["RETENTION_TAG_KEY", "RETENTION_TAG_VALUE"])
+def test_tag_transient_raises_when_a_required_env_var_is_missing(monkeypatch, missing_var):
+    monkeypatch.delenv(missing_var, raising=False)
+    client = FakeS3()
+
+    with pytest.raises(RuntimeError, match=missing_var):
+        tagger.tag_transient(client, "bucket", "run-1/out/sample.bam")
+
+
 def test_handler_skips_retained_suffixes_without_calling_s3():
     client = FakeS3()
 
@@ -128,7 +125,7 @@ def test_handler_skips_retained_suffixes_without_calling_s3():
 
 
 def test_handler_swallows_a_deleted_object():
-    client = FakeS3(get_error=client_error("NoSuchKey"))
+    client = FakeS3(errors={None: client_error("NoSuchKey")})
 
     tagger.handler(s3_event("run-1/out/sample.bam"), None, client=client)
 
@@ -136,7 +133,7 @@ def test_handler_swallows_a_deleted_object():
 
 
 def test_handler_reraises_unexpected_client_errors():
-    client = FakeS3(get_error=client_error("AccessDenied"))
+    client = FakeS3(errors={None: client_error("AccessDenied")})
 
     with pytest.raises(ClientError):
         tagger.handler(s3_event("run-1/out/sample.bam"), None, client=client)
@@ -144,13 +141,9 @@ def test_handler_reraises_unexpected_client_errors():
 
 def test_handler_processes_every_record_in_a_batch():
     client = FakeS3()
-    event = {
-        "Records": [
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/logs/a.log"}}},
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/b.bam"}}},
-        ]
-    }
+    event = s3_event(
+        "run-1/out/a.bam", "run-1/logs/a.log", "run-1/out/b.bam", bucket="b"
+    )
 
     tagger.handler(event, None, client=client)
 
@@ -161,14 +154,10 @@ def test_handler_processes_every_record_in_a_batch():
 
 
 def test_handler_tags_other_records_then_raises_on_unexpected_error():
-    client = KeyedFakeS3(errors={"run-1/out/b.bam": client_error("InvalidTag")})
-    event = {
-        "Records": [
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/b.bam"}}},
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/c.bam"}}},
-        ]
-    }
+    client = FakeS3(errors={"run-1/out/b.bam": client_error("InvalidTag")})
+    event = s3_event(
+        "run-1/out/a.bam", "run-1/out/b.bam", "run-1/out/c.bam", bucket="b"
+    )
 
     with pytest.raises(ClientError):
         tagger.handler(event, None, client=client)
@@ -199,14 +188,10 @@ def test_handler_tags_other_records_and_raises_on_a_malformed_middle_record():
 
 
 def test_handler_tags_other_records_and_does_not_raise_on_a_deleted_middle_record():
-    client = KeyedFakeS3(errors={"run-1/out/b.bam": client_error("NoSuchKey")})
-    event = {
-        "Records": [
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/b.bam"}}},
-            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/c.bam"}}},
-        ]
-    }
+    client = FakeS3(errors={"run-1/out/b.bam": client_error("NoSuchKey")})
+    event = s3_event(
+        "run-1/out/a.bam", "run-1/out/b.bam", "run-1/out/c.bam", bucket="b"
+    )
 
     tagger.handler(event, None, client=client)
 

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -1,0 +1,140 @@
+import pytest
+from botocore.exceptions import ClientError
+
+import tagger
+
+
+class FakeS3:
+    """Minimal stand-in for the S3 client, recording put calls."""
+
+    def __init__(self, tag_set=None, get_error=None):
+        self.tag_set = tag_set if tag_set is not None else []
+        self.get_error = get_error
+        self.put_calls = []
+
+    def get_object_tagging(self, **kwargs):
+        if self.get_error is not None:
+            raise self.get_error
+        return {"TagSet": list(self.tag_set)}
+
+    def put_object_tagging(self, **kwargs):
+        self.put_calls.append(kwargs)
+
+
+def client_error(code, operation="GetObjectTagging"):
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+def s3_event(key, bucket="hfs-bch-raw-output"):
+    return {"Records": [{"s3": {"bucket": {"name": bucket}, "object": {"key": key}}}]}
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "run-1/out/sample.bam",
+        "run-1/out/sample.bam.bai",
+        "run-1/out/coverage.bedgraph",
+        "run-1/out/depth.bw",
+        "run-1/out/variants.vcf.gz",
+        "run-1/out/no-extension",
+        "run-1/out/logs.json.gz",
+    ],
+)
+def test_is_transient_true_for_disposable_outputs(key):
+    assert tagger.is_transient(key) is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "run-1/logs/task.log",
+        "run-1/out/manifest.json",
+        "run-1/logs/TASK.LOG",
+        "run-1/out/MANIFEST.JSON",
+    ],
+)
+def test_is_transient_false_for_retained_suffixes(key):
+    assert tagger.is_transient(key) is False
+
+
+def test_object_keys_decodes_plus_and_percent_escapes():
+    event = s3_event("run+1/out/my+file.bam")
+    assert list(tagger.object_keys(event)) == [
+        ("hfs-bch-raw-output", "run 1/out/my file.bam")
+    ]
+
+    event = s3_event("run-1/out/a%20b.bam")
+    assert list(tagger.object_keys(event)) == [
+        ("hfs-bch-raw-output", "run-1/out/a b.bam")
+    ]
+
+
+def test_tag_transient_preserves_existing_tags():
+    client = FakeS3(tag_set=[{"Key": "created_by", "Value": "terraform"}])
+
+    tagger.tag_transient(client, "bucket", "run-1/out/sample.bam")
+
+    assert client.put_calls == [
+        {
+            "Bucket": "bucket",
+            "Key": "run-1/out/sample.bam",
+            "Tagging": {
+                "TagSet": [
+                    {"Key": "created_by", "Value": "terraform"},
+                    {"Key": "retention", "Value": "transient"},
+                ]
+            },
+        }
+    ]
+
+
+def test_tag_transient_replaces_an_existing_retention_tag():
+    client = FakeS3(tag_set=[{"Key": "retention", "Value": "keep"}])
+
+    tagger.tag_transient(client, "bucket", "run-1/out/sample.bam")
+
+    assert client.put_calls[0]["Tagging"]["TagSet"] == [
+        {"Key": "retention", "Value": "transient"}
+    ]
+
+
+def test_handler_skips_retained_suffixes_without_calling_s3():
+    client = FakeS3()
+
+    tagger.handler(s3_event("run-1/logs/task.log"), None, client=client)
+
+    assert client.put_calls == []
+
+
+def test_handler_swallows_a_deleted_object():
+    client = FakeS3(get_error=client_error("NoSuchKey"))
+
+    tagger.handler(s3_event("run-1/out/sample.bam"), None, client=client)
+
+    assert client.put_calls == []
+
+
+def test_handler_reraises_unexpected_client_errors():
+    client = FakeS3(get_error=client_error("AccessDenied"))
+
+    with pytest.raises(ClientError):
+        tagger.handler(s3_event("run-1/out/sample.bam"), None, client=client)
+
+
+def test_handler_processes_every_record_in_a_batch():
+    client = FakeS3()
+    event = {
+        "Records": [
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/logs/a.log"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/b.bam"}}},
+        ]
+    }
+
+    tagger.handler(event, None, client=client)
+
+    assert [call["Key"] for call in client.put_calls] == [
+        "run-1/out/a.bam",
+        "run-1/out/b.bam",
+    ]

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -21,6 +21,26 @@ class FakeS3:
         self.put_calls.append(kwargs)
 
 
+class KeyedFakeS3:
+    """Stand-in for the S3 client where the failure is keyed per object.
+
+    Lets a single record in a batch fail (or be gone) while the rest succeed.
+    """
+
+    def __init__(self, errors=None):
+        self.errors = errors or {}
+        self.put_calls = []
+
+    def get_object_tagging(self, **kwargs):
+        error = self.errors.get(kwargs["Key"])
+        if error is not None:
+            raise error
+        return {"TagSet": []}
+
+    def put_object_tagging(self, **kwargs):
+        self.put_calls.append(kwargs)
+
+
 def client_error(code, operation="GetObjectTagging"):
     return ClientError({"Error": {"Code": code, "Message": code}}, operation)
 
@@ -137,4 +157,41 @@ def test_handler_processes_every_record_in_a_batch():
     assert [call["Key"] for call in client.put_calls] == [
         "run-1/out/a.bam",
         "run-1/out/b.bam",
+    ]
+
+
+def test_handler_tags_other_records_then_raises_on_unexpected_error():
+    client = KeyedFakeS3(errors={"run-1/out/b.bam": client_error("InvalidTag")})
+    event = {
+        "Records": [
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/b.bam"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/c.bam"}}},
+        ]
+    }
+
+    with pytest.raises(ClientError):
+        tagger.handler(event, None, client=client)
+
+    assert [call["Key"] for call in client.put_calls] == [
+        "run-1/out/a.bam",
+        "run-1/out/c.bam",
+    ]
+
+
+def test_handler_tags_other_records_and_does_not_raise_on_a_deleted_middle_record():
+    client = KeyedFakeS3(errors={"run-1/out/b.bam": client_error("NoSuchKey")})
+    event = {
+        "Records": [
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/a.bam"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/b.bam"}}},
+            {"s3": {"bucket": {"name": "b"}, "object": {"key": "run-1/out/c.bam"}}},
+        ]
+    }
+
+    tagger.handler(event, None, client=client)
+
+    assert [call["Key"] for call in client.put_calls] == [
+        "run-1/out/a.bam",
+        "run-1/out/c.bam",
     ]

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -53,8 +53,8 @@ def s3_event(*keys, bucket="hfs-bch-raw-output"):
         "run-1/out/logs.json.gz",
     ],
 )
-def test_is_transient_true_for_disposable_outputs(key):
-    assert tagger.is_transient(key) is True
+def test_should_expire_true_for_disposable_outputs(key):
+    assert tagger.should_expire(key) is True
 
 
 @pytest.mark.parametrize(
@@ -66,8 +66,8 @@ def test_is_transient_true_for_disposable_outputs(key):
         "run-1/out/MANIFEST.JSON",
     ],
 )
-def test_is_transient_false_for_retained_suffixes(key):
-    assert tagger.is_transient(key) is False
+def test_should_expire_false_for_retained_suffixes(key):
+    assert tagger.should_expire(key) is False
 
 
 def test_record_key_decodes_plus_and_percent_escapes():
@@ -78,10 +78,10 @@ def test_record_key_decodes_plus_and_percent_escapes():
     assert tagger.record_key(record) == ("hfs-bch-raw-output", "run-1/out/a b.bam")
 
 
-def test_tag_transient_preserves_existing_tags():
+def test_tag_for_expiry_preserves_existing_tags():
     client = FakeS3(tag_set=[{"Key": "created_by", "Value": "terraform"}])
 
-    tagger.tag_transient(client, "bucket", "run-1/out/sample.bam")
+    tagger.tag_for_expiry(client, "bucket", "run-1/out/sample.bam")
 
     assert client.put_calls == [
         {
@@ -90,30 +90,30 @@ def test_tag_transient_preserves_existing_tags():
             "Tagging": {
                 "TagSet": [
                     {"Key": "created_by", "Value": "terraform"},
-                    {"Key": "retention", "Value": "transient"},
+                    {"Key": "expire", "Value": "true"},
                 ]
             },
         }
     ]
 
 
-def test_tag_transient_replaces_an_existing_retention_tag():
-    client = FakeS3(tag_set=[{"Key": "retention", "Value": "keep"}])
+def test_tag_for_expiry_replaces_an_existing_expire_tag():
+    client = FakeS3(tag_set=[{"Key": "expire", "Value": "false"}])
 
-    tagger.tag_transient(client, "bucket", "run-1/out/sample.bam")
+    tagger.tag_for_expiry(client, "bucket", "run-1/out/sample.bam")
 
     assert client.put_calls[0]["Tagging"]["TagSet"] == [
-        {"Key": "retention", "Value": "transient"}
+        {"Key": "expire", "Value": "true"}
     ]
 
 
-@pytest.mark.parametrize("missing_var", ["RETENTION_TAG_KEY", "RETENTION_TAG_VALUE"])
-def test_tag_transient_raises_when_a_required_env_var_is_missing(monkeypatch, missing_var):
+@pytest.mark.parametrize("missing_var", ["EXPIRE_TAG_KEY", "EXPIRE_TAG_VALUE"])
+def test_tag_for_expiry_raises_when_a_required_env_var_is_missing(monkeypatch, missing_var):
     monkeypatch.delenv(missing_var, raising=False)
     client = FakeS3()
 
     with pytest.raises(RuntimeError, match=missing_var):
-        tagger.tag_transient(client, "bucket", "run-1/out/sample.bam")
+        tagger.tag_for_expiry(client, "bucket", "run-1/out/sample.bam")
 
 
 def test_handler_skips_retained_suffixes_without_calling_s3():

--- a/variables.tf
+++ b/variables.tf
@@ -206,7 +206,7 @@ variable "output_bucket_expiration_days" {
 }
 
 variable "output_bucket_max_retention_days" {
-  description = "Days after creation that every object in the output bucket is expired regardless of tagging. Bounds the cost if the tagging function stops working, and is therefore also the retention window for HealthOmics run logs and JSON manifests."
+  description = "Days after creation that every object in the output bucket is expired regardless of tagging. Bounds the cost if the tagging function stops working, and is therefore also the retention window for HealthOmics run logs and JSON manifests. Raising this does NOT extend the workflow outputs — those are tagged, so they match both rules and S3 applies the earlier output_bucket_expiration_days. Must stay above output_bucket_expiration_days."
   type        = number
   default     = 90
   nullable    = false

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,7 @@ variable "submit_run_quota" {
 variable "outbound_identity_token_audiences" {
   description = "List of allowed audiences for outbound identity federation tokens (e.g., Client IDs)"
   type        = list(string)
-  default = []
+  default     = []
 }
 
 variable "enable_vpc_networking" {
@@ -191,4 +191,40 @@ variable "configuration_name" {
   type        = string
   default     = null
   nullable    = true
+}
+
+variable "output_bucket_expiration_days" {
+  description = "Days after creation that tagged HealthOmics outputs (everything except run logs and JSON manifests) are expired from the output bucket."
+  type        = number
+  default     = 14
+  nullable    = false
+
+  validation {
+    condition     = var.output_bucket_expiration_days >= 1
+    error_message = "output_bucket_expiration_days must be at least 1."
+  }
+}
+
+variable "output_bucket_max_retention_days" {
+  description = "Days after creation that every object in the output bucket is expired regardless of tagging. Bounds the cost if the tagging function stops working, and is therefore also the retention window for HealthOmics run logs and JSON manifests."
+  type        = number
+  default     = 90
+  nullable    = false
+
+  validation {
+    condition     = var.output_bucket_max_retention_days >= 1
+    error_message = "output_bucket_max_retention_days must be at least 1."
+  }
+}
+
+variable "output_bucket_abort_multipart_days" {
+  description = "Days after initiation that incomplete multipart uploads to the output bucket are aborted."
+  type        = number
+  default     = 7
+  nullable    = false
+
+  validation {
+    condition     = var.output_bucket_abort_multipart_days >= 1
+    error_message = "output_bucket_abort_multipart_days must be at least 1."
+  }
 }


### PR DESCRIPTION
## What

Adds lifecycle expiration to the HealthOmics output bucket, plus the object-tagging
Lambda that makes it expressible.

| Rule | Scope | Window |
|---|---|---|
| `expire-tagged-outputs` | objects tagged `expire=true` | 14 days |
| `expire-all` | every object | 90 days |
| `abort-incomplete-multipart` | incomplete multipart uploads | 7 days |

`hfs-genedx-raw-output` had reached 84,967 GiB with no lifecycle configuration at all.

## Why an object tag rather than a lifecycle filter

S3 lifecycle filters support only prefix, tag and object-size conditions — no suffix
matching, no negation. Output keys are `<run-id>/logs/…` and `<run-id>/out/…`, so no
prefix isolates outputs from the logs and manifests we want to keep. The tagger sees
the full key and tags everything else, so new output types are covered automatically
with no extension list to maintain.

## Why three rules rather than one

`expire-all` runs independently of tagging: an object the tagger never reaches carries
no tag and would otherwise live forever, so a tagging outage is capped at 90 days
instead of unbounded. On a healthy bucket the only objects it ever deletes are the run
logs and manifests, so it doubles as their retention policy.

## Validated on hfs-bch

`8 added, 0 changed, 0 destroyed`. Post-apply: three rules with the correct windows and
tag filter, notification on `s3:ObjectCreated:*`, `.bam`/`.bedgraph` tagged, `.log`/
`.json` left untagged, and a 20 MB multipart upload tagged.

## Notes for reviewers

- The notification must stay `s3:ObjectCreated:*`. Outputs average ~21 GB and arrive as
  `CompleteMultipartUpload`, not `Put`; narrowing it would silently miss 99% of the
  bucket, and small-file tests would still pass.
- The tag is `expire=true`, defined once in `data.tf` locals and passed to the Lambda as
  environment variables, so the tag the Lambda writes can't drift from the tag the
  lifecycle rule filters on.
- `source_code_hash` hashes the committed `.py`, not the archive resource's output, so
  plans don't carry an unknown-at-plan value that would republish the function on every
  run. That leaves one gap — `archive_file` doesn't notice if its output zip is missing
  on disk, so a ForceNew replacement with unchanged source fails; the recovery command
  is documented in-code.
- `s3:PutObjectTagging` is granted only to the tagger's own role; HealthOmics' service
  and user policies are untouched.

Ticket: https://app.clickup.com/t/86bb9p4kc
